### PR TITLE
chore: update shared runner to 0.1.13

### DIFF
--- a/.github/workflows/automation-heartbeat.yml
+++ b/.github/workflows/automation-heartbeat.yml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/.github/workflows/automation-watchdog.yml
+++ b/.github/workflows/automation-watchdog.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/.github/workflows/autonomous-agent.yml
+++ b/.github/workflows/autonomous-agent.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/.github/workflows/autonomous-deploy-execute.yml
+++ b/.github/workflows/autonomous-deploy-execute.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/.github/workflows/ci-failure-dispatch.yml
+++ b/.github/workflows/ci-failure-dispatch.yml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,7 +25,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   NODE_VERSION: '20'
-  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.12"
+  SHARED_RUNNER_COMMAND: "npx -y @takahiro-shimizu-1/automation-runner@0.1.13"
   SHARED_RUNNER_PACKAGE_SCOPE: "@takahiro-shimizu-1"
   SHARED_RUNNER_REGISTRY_URL: "https://npm.pkg.github.com"
   NODE_AUTH_TOKEN: ${{ secrets.AUTOMATION_RUNNER_PACKAGE_TOKEN || github.token }}

--- a/config/shared-runner-profile-manifest.json
+++ b/config/shared-runner-profile-manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "selectedProfile": "deploy-enabled",
-  "runnerCommand": "npx -y @takahiro-shimizu-1/automation-runner@0.1.12",
+  "runnerCommand": "npx -y @takahiro-shimizu-1/automation-runner@0.1.13",
   "runnerPackage": {
     "name": "@takahiro-shimizu-1/automation-runner",
     "scope": "@takahiro-shimizu-1",


### PR DESCRIPTION
## Summary
- refresh generated shared runner wrappers to @takahiro-shimizu-1/automation-runner@0.1.13
- update the deploy-enabled cloud-run profile manifest pin

## Verification
- npm run build
- npm test
- node /home/shimizu/project/automation-hub/bin/automation-runner.mjs topology
- AUTOMATION_CLOUD_RUN_DRY_RUN=true ... cloud-run.sh api