### PR TITLE
[codex] Declare local-main GitNexus membership

### DIFF
--- a/config/shared-runner-profile-manifest.json
+++ b/config/shared-runner-profile-manifest.json
@@ -22,7 +22,15 @@
   },
   "gitnexus": {
     "repoName": "automation-runner-cloud-run-lab",
-    "portfolios": [],
+    "registryName": "automation-runner-cloud-run-lab",
+    "repoSlug": "takahiro-shimizu-1/automation-runner-cloud-run-lab",
+    "portfolios": [
+      {
+        "name": "local-main",
+        "groupPath": "validation/cloud-run",
+        "role": "validation"
+      }
+    ],
     "bootstrap": {
       "enabled": true,
       "defaultCommand": "automation-runner gitnexus-bootstrap"


### PR DESCRIPTION
## What changed
- Declares this repository in the GitNexus portfolio metadata used by automation-hub.
- Keeps the repository-local manifest aligned with the central portfolio config.

## Validation
- automation-hub: npm run typecheck
- automation-hub: npm run ci:repository-topology
- automation-hub: npm run automation:smoke
- GitNexus portfolio reindex, sync, status, doctor, and impact checks for local-main and clean-arch-local
- Changed validation repos: npm test and npm run build
